### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Omnimail/BAO/MailingProviderData.php
+++ b/CRM/Omnimail/BAO/MailingProviderData.php
@@ -13,7 +13,7 @@ class CRM_Omnimail_BAO_MailingProviderData extends CRM_Omnimail_DAO_MailingProvi
     $entityName = 'MailingProviderData';
     $hook = empty($params['id']) ? 'create' : 'edit';
 
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
     $instance = new $className();
     $instance->copyValues($params);
     $instance->save();

--- a/CRM/Omnimail/BAO/OmnimailJobProgress.php
+++ b/CRM/Omnimail/BAO/OmnimailJobProgress.php
@@ -13,7 +13,7 @@ class CRM_Omnimail_BAO_OmnimailJobProgress extends CRM_Omnimail_DAO_OmnimailJobP
     * $entityName = 'OmnimailJobProgress';
     * $hook = empty($params['id']) ? 'create' : 'edit';
  *
-* CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+* CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
     * $instance = new $className();
     * $instance->copyValues($params);
     * $instance->save();

--- a/CRM/Omnimail/Helper.php
+++ b/CRM/Omnimail/Helper.php
@@ -73,7 +73,7 @@ class CRM_Omnimail_Helper {
    */
   public static function getSetting($name) {
     $settings = self::getSettings();
-    return CRM_Utils_Array::value($name, $settings);
+    return $settings[$name] ?? NULL;
   }
 
   /**

--- a/api/v3/Omnigroupmember/Load.php
+++ b/api/v3/Omnigroupmember/Load.php
@@ -24,9 +24,9 @@ use Omnimail\Silverpop\Responses\Contact;
 function civicrm_api3_omnigroupmember_load($params) {
   $values = array();
 
-  $throttleSeconds = CRM_Utils_Array::value('throttle_seconds', $params);
+  $throttleSeconds = $params['throttle_seconds'] ?? NULL;
   $throttleStagePoint = strtotime('+ ' . (int) $throttleSeconds . ' seconds');
-  $throttleCount = (int) CRM_Utils_Array::value('throttle_number', $params);
+  $throttleCount = (int) ($params['throttle_number'] ?? 0);
   $rowsLeftBeforeThrottle = $throttleCount;
 
   $job = new CRM_Omnimail_Omnigroupmembers($params);

--- a/api/v3/Omnirecipient/Load.php
+++ b/api/v3/Omnirecipient/Load.php
@@ -38,16 +38,16 @@ function civicrm_api3_omnirecipient_load($params) {
     $recipients = $omnimail->getResult($params);
     $jobSettings = $omnimail->getJobSettings();
 
-    $throttleSeconds = CRM_Utils_Array::value('throttle_seconds', $params);
+    $throttleSeconds = $params['throttle_seconds'] ?? NULL;
     $throttleStagePoint = strtotime('+ ' . (int) $throttleSeconds . ' seconds');
-    $throttleCount = (int) CRM_Utils_Array::value('throttle_number', $params);
+    $throttleCount = (int) ($params['throttle_number'] ?? 0);
     $rowsLeftBeforeThrottle = $throttleCount;
     $limit = $params['options']['limit'] ?? NULL;
     $count = 0;
-    $insertBatchSize = CRM_Utils_Array::value('insert_batch_size', $params, 1);
+    $insertBatchSize = $params['insert_batch_size'] ?? 1;
     $valueStrings = [];
     $progressSettings = [
-      'last_timestamp' => CRM_Utils_Array::value('last_timestamp', $jobSettings),
+      'last_timestamp' => $jobSettings['last_timestamp'] ?? NULL,
       'retrieval_parameters' => $omnimail->getRetrievalParameters(),
       'progress_end_timestamp' => $omnimail->endTimeStamp,
     ];
@@ -65,7 +65,7 @@ function civicrm_api3_omnirecipient_load($params) {
       $insertValues = [
         1 => [(string) $recipient->getContactIdentifier(), 'String'],
         2 => [
-          (string) CRM_Utils_Array::value('mailing_prefix', $params, '') . $recipient->getMailingIdentifier(),
+          (string) ($params['mailing_prefix'] ?? '') . $recipient->getMailingIdentifier(),
           'String',
         ],
         3 => [(string) $recipient->getEmail(), 'String'],

--- a/api/v3/Omnirecipient/ProcessUnsubscribes.php
+++ b/api/v3/Omnirecipient/ProcessUnsubscribes.php
@@ -35,7 +35,7 @@ function civicrm_api3_omnirecipient_process_unsubscribes($params) {
     ));
     civicrm_api3('Activity', 'create', array(
       'activity_type_id' => 'Unsubscribe',
-      'campaign_id' => CRM_Utils_Array::value('mailing_identifier.campaign_id.name', $unsubscribes),
+      'campaign_id' => $unsubscribes['mailing_identifier.campaign_id.name'] ?? NULL,
       'target_contact_id' => $unsubscribes['contact_id'],
       'source_contact_id' =>  $unsubscribes['contact_id'],
       'activity_date_time' => $unsubscribes['recipient_action_datetime'],


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.