### PR TITLE
Remove commented-out boilerplate

### DIFF
--- a/CRM/Omnimail/BAO/MailingProviderData.php
+++ b/CRM/Omnimail/BAO/MailingProviderData.php
@@ -2,24 +2,5 @@
 
 class CRM_Omnimail_BAO_MailingProviderData extends CRM_Omnimail_DAO_MailingProviderData {
 
-  /**
-   * Create a new MailingProviderData based on array-data
-   *
-   * @param array $params key-value pairs
-   * @return CRM_Omnimail_DAO_MailingProviderData|NULL
-   *
-  public static function create($params) {
-    $className = 'CRM_Omnimail_DAO_MailingProviderData';
-    $entityName = 'MailingProviderData';
-    $hook = empty($params['id']) ? 'create' : 'edit';
-
-    CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
-    $instance = new $className();
-    $instance->copyValues($params);
-    $instance->save();
-    CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
-
-    return $instance;
-  } */
 
 }

--- a/CRM/Omnimail/BAO/OmnimailJobProgress.php
+++ b/CRM/Omnimail/BAO/OmnimailJobProgress.php
@@ -2,24 +2,5 @@
 
 class CRM_Omnimail_BAO_OmnimailJobProgress extends CRM_Omnimail_DAO_OmnimailJobProgress {
 
-  /**
-   * Create a new OmnimailJobProgress based on array-data
-   *
-   * @param array $params key-value pairs
-   * @return CRM_Omnimail_DAO_OmnimailJobProgress
-   *
-   * public static function create($params) {
-    * $className = 'CRM_Omnimail_DAO_OmnimailJobProgress';
-    * $entityName = 'OmnimailJobProgress';
-    * $hook = empty($params['id']) ? 'create' : 'edit';
- *
-* CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
-    * $instance = new $className();
-    * $instance->copyValues($params);
-    * $instance->save();
-    * CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
- *
-* return $instance;
-  * } */
 
 }


### PR DESCRIPTION
Civix used to generate commented-out BAO create functions, however all BAOs now inherit writeRecords() from their parent.

Since this function was never uncommented, it's safe to remove.